### PR TITLE
fix: Correct maxAge examples from milliseconds to seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ export async function middleware(request: NextRequest) {
       httpOnly: true,
       secure: false, // set to 'true' on https environments
       sameSite: 'lax',
-      maxAge: 12 * 60 * 60 * 24 * 1000, // twelve days
+      maxAge: 12 * 60 * 60 * 24, // twelve days
     },
     cookieSignatureKeys: ["secret1", "secret2"],
     serviceAccount: {
@@ -447,7 +447,7 @@ const commonOptions = {
     httpOnly: true,
     secure: false, // Set this to true on HTTPS environments
     sameSite: "strict" as const,
-    maxAge: 12 * 60 * 60 * 24 * 1000, // twelve days
+    maxAge: 12 * 60 * 60 * 24, // twelve days
   },
   serviceAccount: {
     projectId: "firebase-project-id",
@@ -575,7 +575,7 @@ export default async function handler(
       httpOnly: true,
       secure: false, // Set this to true on HTTPS environments
       sameSite: "strict" as const,
-      maxAge: 12 * 60 * 60 * 24 * 1000, // twelve days
+      maxAge: 12 * 60 * 60 * 24, // twelve days
     },
   });
 

--- a/examples/next13-typescript-firebaseui/config/server-config.ts
+++ b/examples/next13-typescript-firebaseui/config/server-config.ts
@@ -17,7 +17,7 @@ export const authConfig = {
     httpOnly: true,
     secure: serverConfig.useSecureCookies, // Set this to true on HTTPS environments
     sameSite: "lax" as const,
-    maxAge: 12 * 60 * 60 * 24 * 1000, // twelve days
+    maxAge: 12 * 60 * 60 * 24, // twelve days
   },
   serviceAccount: serverConfig.serviceAccount,
 };

--- a/examples/next13-typescript-starter/config/server-config.ts
+++ b/examples/next13-typescript-starter/config/server-config.ts
@@ -17,7 +17,7 @@ export const authConfig = {
     httpOnly: true,
     secure: serverConfig.useSecureCookies, // Set this to true on HTTPS environments
     sameSite: "lax" as const,
-    maxAge: 12 * 60 * 60 * 24 * 1000, // twelve days
+    maxAge: 12 * 60 * 60 * 24, // twelve days
   },
   serviceAccount: serverConfig.serviceAccount,
 };


### PR DESCRIPTION
`cookie` library expects `maxAge` set in [seconds not milliseconds](https://github.com/jshttp/cookie#maxage). This PR replaces all examples of setting cookie maxAge in this repo with seconds. 

For anyone that has the same issue in the future: I was facing a bug in my own repository using `next-firebase-auth-edge` where cookies were unexpectedly being set to 400 days in the future. This is because this is Chrome's maximum future cookie age, and I'd been setting `maxAge` in milliseconds. 

