### PR TITLE
chore: add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
   ],
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/awinogrodzki/next-firebase-auth-edge.git"
+  },
   "engines": {
     "node": ">=16.0.0 <20.0.0",
     "npm": ">=8.0.0 <10.0.0",


### PR DESCRIPTION
Add `repository` url, so that it is displayed in NPM and so that other tools can leverage this information.

Docs: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository