### PR TITLE
fix: getCustomTokenEndpoint to not add http when its already has http://

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -12,8 +12,12 @@ import { AuthError, AuthErrorCode } from "./error";
 import { VerifyOptions } from "./jwt/verify";
 
 const getCustomTokenEndpoint = (apiKey: string) => {
-  if (useEmulator()) {
-    return `http://${process.env
+  if (useEmulator() && process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+    let protocol = 'http://';
+    if((process.env.FIREBASE_AUTH_EMULATOR_HOST as string).startsWith('http://')) {
+      protocol = "";
+    }
+    return `${protocol}${process.env
       .FIREBASE_AUTH_EMULATOR_HOST!}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${apiKey}`;
   }
 
@@ -21,8 +25,14 @@ const getCustomTokenEndpoint = (apiKey: string) => {
 };
 
 const getRefreshTokenEndpoint = (apiKey: string) => {
-  if (useEmulator()) {
-    return `http://${process.env
+
+  if (useEmulator() && process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+    let protocol = 'http://';
+    if((process.env.FIREBASE_AUTH_EMULATOR_HOST as string).startsWith('http://')) {
+      protocol = "";
+    }
+
+    return `${protocol}${process.env
       .FIREBASE_AUTH_EMULATOR_HOST!}/securetoken.googleapis.com/v1/token?key=${apiKey}`;
   }
 


### PR DESCRIPTION
Check if the `FIREBASE_AUTH_EMULATOR_HOST` has already http:// added to it, otherwise you will get a cryptic fetch failed error.. 