### PR TITLE
feat: Support use of tenantId in refreshAuthCookie().

### DIFF
--- a/src/next/cookies.ts
+++ b/src/next/cookies.ts
@@ -154,7 +154,8 @@ export async function refreshAuthCookies(
 ): Promise<IdAndRefreshTokens> {
   const { getCustomIdAndRefreshTokens } = getFirebaseAuth(
     options.serviceAccount,
-    options.apiKey
+    options.apiKey,
+    options.tenantId
   );
   const idAndRefreshTokens = await getCustomIdAndRefreshTokens(
     idToken,

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -81,7 +81,8 @@ export async function refreshAuthCookies(
 ): Promise<IdAndRefreshTokens> {
   const { getCustomIdAndRefreshTokens } = getFirebaseAuth(
     options.serviceAccount,
-    options.apiKey
+    options.apiKey,
+    options.tenantId
   );
   const idAndRefreshTokens = await getCustomIdAndRefreshTokens(
     idToken,


### PR DESCRIPTION
A small follow up to https://github.com/awinogrodzki/next-firebase-auth-edge/pull/101 to support use of tenantId in the `refreshAuthCookies()` method in `src/next/cookies` and `src/next/middleware`.