### PR TITLE
fix: remove fetch `cache: no-store` due to #173

### DIFF
--- a/src/auth/signature-verifier.ts
+++ b/src/auth/signature-verifier.ts
@@ -67,10 +67,7 @@ export class UrlKeyFetcher implements KeyFetcher {
   }
 
   private async fetchPublicKeysResponse(url: URL): Promise<PublicKeysResponse> {
-    const res = await fetch(url, {
-      cache: 'no-store'
-    });
-
+    const res = await fetch(url);
     const headers = {};
 
     res.headers.forEach((value, key) => {


### PR DESCRIPTION
Resolves #173 

`cache: no-store` was introduced to resolve caching issue in Next.js 13.5.  Passing `cache` property causes error in Cloudflare Workers due to https://github.com/cloudflare/workerd/issues/698.  

This PR removes the usages of `cache` fetch option

Due to above, it's recommended to update Next.js to v14 along with the upgrade to next-firebase-auth-edge@1.5 to avoid caching issues