### PR TITLE
Fix "process is not defined" for createCustomToken in CF Worker

### DIFF
--- a/src/auth/firebase.ts
+++ b/src/auth/firebase.ts
@@ -4,6 +4,7 @@ export const CLIENT_CERT_URL =
   'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
 
 export function emulatorHost(): string | undefined {
+  if (typeof process === 'undefined') return undefined;
   return process.env.FIREBASE_AUTH_EMULATOR_HOST;
 }
 


### PR DESCRIPTION
Solves https://github.com/awinogrodzki/next-firebase-auth-edge/issues/192

By checking first whether or not process is defined, we can prevent a runtime error, allowing the use of `createCustomToken` in CF Worker.

As I've only been testing the `createCustomToken` method, in other places `process.env` might be accessed in an insecure way as well.