### PR TITLE
feat: add path to redirectToHome

### DIFF
--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -34,9 +34,17 @@ export interface CreateAuthMiddlewareOptions {
   enableMultipleCookies?: boolean;
 }
 
-export function redirectToHome(request: NextRequest) {
+interface RedirectToHomeOptions {
+  path: string;
+}
+
+export function redirectToHome(request: NextRequest,
+  options: RedirectToHomeOptions = {
+    path: '/'
+  }
+) {
   const url = request.nextUrl.clone();
-  url.pathname = '/';
+  url.pathname = options.path;
   url.search = '';
   return NextResponse.redirect(url);
 }


### PR DESCRIPTION
Hello, I really liked this package! I would like to contribute my grain of sand!

I found that normally you would like to set the home path (aka "/") to be public. The problem is that, following the example provided in the starter kit, using  `redirectToHome` would let to infinite redirects. Also, sometimes 'Home' would be a path like `/dashboard`.

So we were changing from this:
``` typescript
 handleValidToken: async ({token, decodedToken}, headers) => {
      if (PUBLIC_PATHS.includes(request.nextUrl.pathname)) {
        return redirectToHome(request);
      }
      // ....
}
```
to this:
``` typescript
 handleValidToken: async ({token, decodedToken}, headers) => {
      if (PUBLIC_PATHS.includes(request.nextUrl.pathname)) {
        return redirectToHome(request, { path: "/dashboard" });
      }
      // ....
}
```