### PR TITLE
feat(getTokens): introduced optional `cookieSerializeOptions` option

### DIFF
--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -19,11 +19,7 @@ import {
   wasResponseDecoratedWithModifiedRequestHeaders
 } from './cookies';
 import {refreshToken} from './refresh-token';
-import {
-  getRequestCookiesTokens,
-  GetTokensOptions,
-  validateOptions
-} from './tokens';
+import {getRequestCookiesTokens, validateOptions} from './tokens';
 import {getReferer} from './utils';
 
 export interface CreateAuthMiddlewareOptions {
@@ -123,14 +119,15 @@ export type HandleValidToken = (
 ) => Promise<NextResponse>;
 export type HandleError = (e: unknown) => Promise<NextResponse>;
 
-export interface AuthMiddlewareOptions
-  extends CreateAuthMiddlewareOptions,
-    GetTokensOptions {
+export interface AuthMiddlewareOptions extends CreateAuthMiddlewareOptions {
+  serviceAccount?: ServiceAccount;
+  apiKey: string;
+  debug?: boolean;
+  headers?: Headers;
   checkRevoked?: boolean;
   handleInvalidToken?: HandleInvalidToken;
   handleValidToken?: HandleValidToken;
   handleError?: HandleError;
-  debug?: boolean;
 }
 
 const defaultInvalidTokenHandler = async () => NextResponse.next();

--- a/src/next/tokens.ts
+++ b/src/next/tokens.ts
@@ -12,11 +12,14 @@ import {debug, enableDebugMode} from '../debug';
 import {
   CookiesObject,
   areCookiesVerifiedByMiddleware,
+  createVerifier,
   isCookiesObjectVerifiedByMiddleware
 } from './cookies';
 import {getReferer} from './utils';
+import {CookieSerializeOptions} from 'cookie';
 
 export interface GetTokensOptions extends GetCookiesTokensOptions {
+  cookieSerializeOptions?: CookieSerializeOptions;
   serviceAccount?: ServiceAccount;
   apiKey: string;
   debug?: boolean;
@@ -80,10 +83,18 @@ function toTokens(result: VerifiedTokens | null): Tokens | null {
   };
 }
 
+function isReadonly(
+  cookies: RequestCookies | ReadonlyRequestCookies
+): cookies is ReadonlyRequestCookies {
+  return !Object.hasOwn(cookies, 'set');
+}
+
 export async function getTokens(
   cookies: RequestCookies | ReadonlyRequestCookies,
   options: GetTokensOptions
 ): Promise<Tokens | null> {
+  const now = Date.now();
+
   if (options.debug) {
     enableDebugMode();
   }
@@ -99,8 +110,10 @@ export async function getTokens(
 
   try {
     const tokens = await getRequestCookiesTokens(cookies, options);
+    debug('getTokens: Tokens successfully extracted from cookies');
 
     if (areCookiesVerifiedByMiddleware(cookies)) {
+      debug('getTokens: Cookies are marked as verified. Skipping verification');
       const payload = decodeJwt(tokens.idToken);
 
       return {
@@ -110,7 +123,43 @@ export async function getTokens(
       };
     }
 
-    const result = await verifyAndRefreshExpiredIdToken(tokens, {referer});
+    const result = await verifyAndRefreshExpiredIdToken(tokens, {
+      referer,
+      async onTokenRefresh({idToken, refreshToken, customToken}) {
+        const cookieSerializeOptions = options.cookieSerializeOptions;
+
+        if (isReadonly(cookies) || !cookieSerializeOptions) {
+          debug(
+            'getTokens: Expired tokens have been refreshed, but were not set on the response',
+            {
+              hasCookieSerializeOptions: !!cookieSerializeOptions,
+              isReadonly: isReadonly(cookies)
+            }
+          );
+
+          return;
+        }
+
+        debug(
+          'getTokens: Expired tokens have been refreshed and new credentials will be set on the response'
+        );
+
+        const tokensToSign = {
+          idToken,
+          refreshToken,
+          customToken
+        };
+
+        const verifier = createVerifier(tokensToSign, {
+          ...options,
+          cookieSerializeOptions
+        });
+
+        await verifier.init();
+
+        verifier.appendCookies(cookies);
+      }
+    });
 
     return toTokens(result);
   } catch (error: unknown) {
@@ -125,6 +174,8 @@ export async function getTokens(
     }
 
     throw error;
+  } finally {
+    debug(`getTokens: took ${(Date.now() - now) / 1000}ms`);
   }
 }
 


### PR DESCRIPTION
Related to #237

When ID token is expired and [middleware token verification caching](https://next-firebase-auth-edge-docs.vercel.app/docs/usage/middleware#middleware-token-verification-caching) is not enabled, `getTokens` might perform a token refresh without updating the response when called from Server Action. It may result in token being refreshed multiple times.

This PR introduces optional `cookieSerializeOptions` parameter to `getTokens` function. When `cookieSerializeOptions` is provided and `getTokens` is called with `RequestCookies` rather than `ReadonlyRequestCookies`, cookies are updated, resulting in response containing `Set-Cookie` headers with updated credentials

 