### PR TITLE
fix(#242): use TextEncoder when mapping token to UInt8Array

### DIFF
--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -108,6 +108,8 @@ export function deepExtend<T>(target: T, source: T): T {
   return target;
 }
 
+const encoder = new TextEncoder();
+
 export function toUint8Array(key: string) {
-  return Uint8Array.from(key.split('').map((x) => x.charCodeAt(0)));
+  return encoder.encode(key);
 }


### PR DESCRIPTION
#242 couldn't be reproduced on macOS.

 This PR implements resolution from https://github.com/panva/jose/discussions/427
 

