### PR TITLE
Feat/refresh token on no matching kid experimental

### DIFF
--- a/src/auth/error.ts
+++ b/src/auth/error.ts
@@ -39,8 +39,8 @@ function mergeStackTraceAndCause(target: Error, original: unknown) {
   const originalCause =
     typeof originalError?.cause === 'string' ? originalError.cause : '';
 
-  target.stack = originalErrorStack + (target?.stack ?? '');
-  target.cause = originalCause + (target?.cause ?? '');
+  target.stack = (target?.stack ?? '') + originalErrorStack;
+  target.cause = (target?.cause ?? '') + originalCause;
 }
 
 export class AuthError extends Error {

--- a/src/auth/jwt/verify.ts
+++ b/src/auth/jwt/verify.ts
@@ -14,6 +14,7 @@ export interface VerifyOptions {
   currentDate?: Date;
   checkRevoked?: boolean;
   referer?: string;
+  experimental_enableTokenRefreshOnExpiredKidHeader?: boolean;
 }
 
 const keyMap: Map<string, KeyLike> = new Map();

--- a/src/auth/test/no-matching-kid.integration.test.ts
+++ b/src/auth/test/no-matching-kid.integration.test.ts
@@ -1,0 +1,96 @@
+import {v4} from 'uuid';
+import {CLIENT_CERT_URL} from '../firebase';
+import {customTokenToIdAndRefreshTokens, getFirebaseAuth} from '../index';
+import {InvalidTokenError, InvalidTokenReason} from '../error';
+
+const {
+  FIREBASE_API_KEY,
+  FIREBASE_PROJECT_ID,
+  FIREBASE_ADMIN_CLIENT_EMAIL,
+  FIREBASE_ADMIN_PRIVATE_KEY
+} = process.env;
+
+const TEST_SERVICE_ACCOUNT = {
+  clientEmail: FIREBASE_ADMIN_CLIENT_EMAIL!,
+  privateKey: FIREBASE_ADMIN_PRIVATE_KEY!.replace(/\\n/g, '\n'),
+  projectId: FIREBASE_PROJECT_ID!
+};
+
+const REFERER = 'http://localhost:3000';
+
+describe('no matching kid integration test', () => {
+  const {createCustomToken, verifyAndRefreshExpiredIdToken} = getFirebaseAuth(
+    TEST_SERVICE_ACCOUNT,
+    FIREBASE_API_KEY!
+  );
+
+  beforeEach(() => {
+    let numberOfCalls = 0;
+
+    const actualFetch = global.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.fetch = jest.fn((url: URL, ...args: any[]) => {
+      if (url?.href === CLIENT_CERT_URL && !numberOfCalls) {
+        numberOfCalls++;
+        return {
+          ok: true,
+          headers: {
+            forEach: () => {},
+            has: () => false
+          },
+          json: () => Promise.resolve({})
+        };
+      }
+
+      return actualFetch(url, ...args);
+    }) as jest.Mock;
+  });
+
+  it('should throw invalid token error if kid header does not match public keys', async () => {
+    const userId = v4();
+    const customToken = await createCustomToken(userId, {
+      customClaim: 'customClaimValue'
+    });
+
+    const {idToken, refreshToken} = await customTokenToIdAndRefreshTokens(
+      customToken,
+      FIREBASE_API_KEY!,
+      {referer: REFERER}
+    );
+
+    return expect(() =>
+      verifyAndRefreshExpiredIdToken(
+        {idToken, refreshToken, customToken},
+        {
+          referer: REFERER
+        }
+      )
+    ).rejects.toEqual(new InvalidTokenError(InvalidTokenReason.INVALID_KID));
+  });
+
+  it('should refresh the token if kid header does not match public keys and experimental flag is provided', async () => {
+    const userId = v4();
+    const customToken = await createCustomToken(userId, {
+      customClaim: 'customClaimValue'
+    });
+
+    const {idToken, refreshToken} = await customTokenToIdAndRefreshTokens(
+      customToken,
+      FIREBASE_API_KEY!,
+      {referer: REFERER}
+    );
+
+    const onTokenRefresh = jest.fn();
+
+    const result = await verifyAndRefreshExpiredIdToken(
+      {idToken, refreshToken, customToken},
+      {
+        referer: REFERER,
+        experimental_enableTokenRefreshOnExpiredKidHeader: true,
+        onTokenRefresh
+      }
+    );
+
+    expect(onTokenRefresh).toHaveBeenCalledWith(result);
+  });
+});

--- a/src/auth/test/verify-token.integration.test.ts
+++ b/src/auth/test/verify-token.integration.test.ts
@@ -104,15 +104,19 @@ describe('verify token integration test', () => {
           {tenantId, appCheckToken: appCheckToken.token, referer: REFERER}
         );
 
+        const onTokenRefresh = jest.fn();
+
         const result = await verifyAndRefreshExpiredIdToken(
           {idToken, refreshToken, customToken},
           {
             currentDate: new Date(Date.now() + 7200 * 1000),
-            referer: REFERER
+            referer: REFERER,
+            onTokenRefresh
           }
         );
 
         expect(result?.decodedIdToken?.customClaim).toEqual('customClaimValue');
+        expect(onTokenRefresh).toHaveBeenCalledWith(result);
       });
 
       it('should verify token', async () => {

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -128,6 +128,7 @@ export interface AuthMiddlewareOptions extends CreateAuthMiddlewareOptions {
   handleInvalidToken?: HandleInvalidToken;
   handleValidToken?: HandleValidToken;
   handleError?: HandleError;
+  experimental_enableTokenRefreshOnExpiredKidHeader?: boolean;
 }
 
 const defaultInvalidTokenHandler = async () => NextResponse.next();
@@ -269,7 +270,8 @@ export async function authMiddleware(
         debug('Authentication failed with error', {error: e});
 
         return handleError(e);
-      }
+      },
+      options.experimental_enableTokenRefreshOnExpiredKidHeader ?? false
     );
   } catch (error: unknown) {
     if (error instanceof InvalidTokenError) {

--- a/src/next/tokens.ts
+++ b/src/next/tokens.ts
@@ -24,6 +24,7 @@ export interface GetTokensOptions extends GetCookiesTokensOptions {
   apiKey: string;
   debug?: boolean;
   headers?: Headers;
+  experimental_enableTokenRefreshOnExpiredKidHeader?: boolean;
 }
 
 export function validateOptions(options: GetTokensOptions) {
@@ -125,6 +126,8 @@ export async function getTokens(
 
     const result = await verifyAndRefreshExpiredIdToken(tokens, {
       referer,
+      experimental_enableTokenRefreshOnExpiredKidHeader:
+        options.experimental_enableTokenRefreshOnExpiredKidHeader,
       async onTokenRefresh({idToken, refreshToken, customToken}) {
         const cookieSerializeOptions = options.cookieSerializeOptions;
 


### PR DESCRIPTION
In #231 question was raised about possible token refresh on expired kid header

This PR brings back experimental option to refresh tokens after kid header has expired