### PR TITLE
fix: return cached token from getValidIdToken

### DIFF
--- a/src/next/client.ts
+++ b/src/next/client.ts
@@ -43,7 +43,7 @@ export async function getValidIdToken({
   const exp = payload?.exp ?? 0;
 
   if (!checkRevoked && exp > Date.now() / 1000) {
-    return token;
+    return token || serverIdToken;
   }
 
   const response = await fetchApi<{idToken: string}>(refreshTokenUrl);
@@ -81,7 +81,7 @@ export async function getValidCustomToken({
   const exp = payload?.exp ?? 0;
 
   if (!checkRevoked && exp > Date.now() / 1000) {
-    return token;
+    return token || serverCustomToken;
   }
 
   const response = await fetchApi<{customToken: string}>(refreshTokenUrl);

--- a/src/next/client.ts
+++ b/src/next/client.ts
@@ -43,7 +43,7 @@ export async function getValidIdToken({
   const exp = payload?.exp ?? 0;
 
   if (!checkRevoked && exp > Date.now() / 1000) {
-    return serverIdToken;
+    return token;
   }
 
   const response = await fetchApi<{idToken: string}>(refreshTokenUrl);
@@ -81,7 +81,7 @@ export async function getValidCustomToken({
   const exp = payload?.exp ?? 0;
 
   if (!checkRevoked && exp > Date.now() / 1000) {
-    return serverCustomToken;
+    return token;
   }
 
   const response = await fetchApi<{customToken: string}>(refreshTokenUrl);


### PR DESCRIPTION
This change ensures getValidIdToken and getValidCustomToken actually return the refreshed token from the cache on subsequent calls to the function.

Without this change, getValidIdToken and and getValidCustomToken only return the fresh token immediately after refreshing. Otherwise the functions return the argument serverIdToken or serverCustomToken which is likely the original, expired token. This is because internally the expiry check happens against the cached, fresh token.

The caller of getValidIdToken and and getValidCustomToken is typically not able to update the value they pass as the "initial" token in memory. For example, because it comes from a call to getTokens that is only made on a full page reload.

Fixes #291