### PR TITLE
Add middleware option `experimental_createAnonymousUserIfUserNotFound`

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -45,6 +45,10 @@ const getCustomTokenEndpoint = (apiKey: string) => {
   return `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${apiKey}`;
 };
 
+const getSignUpEndpoint = (apiKey: string) => {
+  return `https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=${apiKey}`;
+};
+
 const getRefreshTokenEndpoint = (apiKey: string) => {
   if (useEmulator() && process.env.FIREBASE_AUTH_EMULATOR_HOST) {
     let protocol = 'http://';
@@ -112,6 +116,36 @@ export async function customTokenToIdAndRefreshTokens(
     idToken: refreshTokenJSON.idToken as string,
     refreshToken: refreshTokenJSON.refreshToken as string
   };
+}
+
+export async function createAnonymousAccount(
+  firebaseApiKey: string,
+  options: CreateAnonymousRequest = {}
+): Promise<AnonymousTokens> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.referer ? {Referer: options.referer} : {})
+  };
+
+  const body: Record<string, string | boolean> = {
+    returnSecureToken: true
+  };
+
+  if (options.appCheckToken) {
+    headers['X-Firebase-AppCheck'] = options.appCheckToken;
+  }
+
+  if (options.tenantId) {
+    body['tenantId'] = options.tenantId;
+  }
+
+  const createResponse = await fetch(getSignUpEndpoint(firebaseApiKey), {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+
+  return (await createResponse.json()) as AnonymousTokens;
 }
 
 interface ErrorResponse {
@@ -248,11 +282,23 @@ export interface IdAndRefreshTokens {
   refreshToken: string;
 }
 
+export interface CreateAnonymousRequest {
+  tenantId?: string;
+  appCheckToken?: string;
+  referer?: string;
+}
+
 export interface Tokens {
   decodedToken: DecodedIdToken;
   token: string;
   // Set `enableCustomToken` to true in `authMiddleware` to enable custom token
   customToken?: string;
+}
+
+export interface AnonymousTokens {
+  idToken: string;
+  refreshToken: string;
+  localId: string;
 }
 
 export interface UsersList {
@@ -520,6 +566,12 @@ function getAuth(options: AuthOptions) {
       });
   }
 
+  async function createAnonymousUser(
+    firebaseApiKey: string
+  ): Promise<AnonymousTokens> {
+    return createAnonymousAccount(firebaseApiKey);
+  }
+
   async function updateUser(
     uid: string,
     properties: UpdateRequest
@@ -551,6 +603,7 @@ function getAuth(options: AuthOptions) {
     getUserByEmail,
     updateUser,
     createUser,
+    createAnonymousUser,
     listUsers,
     createSessionCookie
   };

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -288,8 +288,6 @@ export async function authMiddleware(
           options
         );
 
-        // @TODO: Clear legacy cookies only after setting headers
-        // Possible fix: clone request cookies in provider constructor
         await cookies.setAuthCookies(tokensToSign, request.cookies);
 
         markCookiesAsVerified(request.cookies);
@@ -345,8 +343,6 @@ export async function authMiddleware(
           options
         );
 
-        // @TODO: Clear legacy cookies only after setting headers
-        // Possible fix: clone request cookies in provider constructor
         await cookies.setAuthCookies(tokensToSign, request.cookies);
 
         const decodedToken = await verifyIdToken(idToken, {


### PR DESCRIPTION
Initially called out in https://github.com/awinogrodzki/next-firebase-auth-edge/issues/294

The goal of this PR is to add middleware to create a new anonymous user on initial load. It's worth debating if the additional middleware request time is worth the mess, or if this should always be done after the initial load. In any case, I learned a lot by poking at this sdk