### PR TITLE
Add a logout-with-server-action page to the docs

### DIFF
--- a/docs/pages/docs/getting-started/_meta.json
+++ b/docs/pages/docs/getting-started/_meta.json
@@ -5,5 +5,6 @@
   "auth-provider": "AuthProvider",
   "layout": "Layout",
   "login-page": "Usage with Firebase Auth",
-  "login-with-server-action": "Sign in with Server Action"
+  "login-with-server-action": "Sign in with Server Action",
+  "logout-with-server-action": "Sign out with Server Action"
 }

--- a/docs/pages/docs/getting-started/logout-with-server-action.mdx
+++ b/docs/pages/docs/getting-started/logout-with-server-action.mdx
@@ -1,0 +1,62 @@
+# Sign out with Server Action
+
+## removeServerCookies [v 1.9.0-canary.4]
+
+The `removeServerCookies` method removes server cookies from the browser. This method works with **Server Actions** and **Middleware**. 
+After logging out with Firebase in a Server Action, you can use this method to remove the server cookies from the browser.
+
+Prior to version `1.9.0-canary.4`, the `removeServerCookies` method was not available. Instead, you had to manually remove them from the browser.
+
+```tsx
+cookies.delete(authConfig.cookieName + ".id");
+cookies.delete(authConfig.cookieName + ".refresh");
+cookies.delete(authConfig.cookieName + ".sig");
+```
+
+## Example logoutAction and LogoutPage
+
+Below is a simple example of a logout page client component that lets users sign out using a Server Action and the `removeServerCookies` method.
+
+First, let’s define our Server Action:
+
+```tsx filename="logout.tsx"
+'use server';
+
+import {removeServerCookies} from "next-firebase-auth-edge/next/cookies";
+import {signOut} from 'firebase/auth';
+import {cookies} from 'next/headers';
+import {redirect} from 'next/navigation';
+import {getFirebaseAuth} from '@/app/auth/firebase';
+import {authConfig} from '@/config/server-config';
+
+export async function logoutAction() {
+  await signOut(getFirebaseAuth());
+
+  // Since Next.js 15, `headers` and `cookies` functions return a Promise, hence we precede the calls with `await`.
+  removeServerCookies(await cookies(), { cookieName: authConfig.cookieName });
+  redirect('/');
+}
+```
+
+Next, create LogoutPage client component that will call logout action:
+
+```tsx filename="LogoutPage.tsx"
+'use client';
+
+import * as React from 'react';
+
+interface LogoutPageProps {
+  logoutAction: () => void;
+}
+
+export default function LogoutPage({logoutAction}: LogoutPageProps) {
+    return (
+        <div>
+            <h1>Logout</h1>
+            <form action={logoutAction}>
+                <button type="submit">Sign out</button>
+            </form>
+        </div>
+    );
+}
+```

--- a/docs/pages/docs/getting-started/logout-with-server-action.mdx
+++ b/docs/pages/docs/getting-started/logout-with-server-action.mdx
@@ -1,17 +1,29 @@
 # Sign out with Server Action
 
-## removeServerCookies [v 1.9.0-canary.4]
+## removeServerCookies [v1.9.0]
 
 The `removeServerCookies` method removes server cookies from the browser. This method works with **Server Actions** and **Middleware**. 
 After logging out with Firebase in a Server Action, you can use this method to remove the auth cookies from the browser.
 
-Prior to version `1.9.0-canary.4`, the `removeServerCookies` method was not available. Instead, you had to manually remove the cookies from the browser.
+Prior to version `1.9.0`, the `removeServerCookies` method was not available. Instead, you had to manually remove the cookies from the browser.
+
+With multiple cookies enabled:
 
 ```tsx
 cookies.delete(authConfig.cookieName + ".id");
 cookies.delete(authConfig.cookieName + ".refresh");
 cookies.delete(authConfig.cookieName + ".sig");
+
+// Optionally, if you enabled custom token:
+cookies.delete(authConfig.cookieName + ".custom");
 ```
+
+Without multiple cookies enabled:
+
+```tsx
+cookies.delete(authConfig.cookieName);
+```
+
 
 ## Example logoutAction and LogoutPage
 

--- a/docs/pages/docs/getting-started/logout-with-server-action.mdx
+++ b/docs/pages/docs/getting-started/logout-with-server-action.mdx
@@ -3,9 +3,9 @@
 ## removeServerCookies [v 1.9.0-canary.4]
 
 The `removeServerCookies` method removes server cookies from the browser. This method works with **Server Actions** and **Middleware**. 
-After logging out with Firebase in a Server Action, you can use this method to remove the server cookies from the browser.
+After logging out with Firebase in a Server Action, you can use this method to remove the auth cookies from the browser.
 
-Prior to version `1.9.0-canary.4`, the `removeServerCookies` method was not available. Instead, you had to manually remove them from the browser.
+Prior to version `1.9.0-canary.4`, the `removeServerCookies` method was not available. Instead, you had to manually remove the cookies from the browser.
 
 ```tsx
 cookies.delete(authConfig.cookieName + ".id");
@@ -15,7 +15,7 @@ cookies.delete(authConfig.cookieName + ".sig");
 
 ## Example logoutAction and LogoutPage
 
-Below is a simple example of a logout page client component that lets users sign out using a Server Action and the `removeServerCookies` method.
+Below is a simple example of a logout page component that lets users sign out using a Server Action and the `removeServerCookies` method.
 
 First, let’s define our Server Action:
 
@@ -38,13 +38,9 @@ export async function logoutAction() {
 }
 ```
 
-Next, create LogoutPage client component that will call logout action:
+Next, create LogoutPage component that will call logout action:
 
 ```tsx filename="LogoutPage.tsx"
-'use client';
-
-import * as React from 'react';
-
 interface LogoutPageProps {
   logoutAction: () => void;
 }


### PR DESCRIPTION
This comes from this [issue](https://github.com/awinogrodzki/next-firebase-auth-edge/issues/300) 