### PR TITLE
middleware is not wokring properly if the request url contains dot or .

### DIFF
--- a/examples/next-typescript-minimal/middleware.ts
+++ b/examples/next-typescript-minimal/middleware.ts
@@ -47,7 +47,7 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     "/",
-    "/((?!_next|api|.*\\.).*)",
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     "/api/login",
     "/api/logout",
   ],

--- a/examples/next-typescript-starter/middleware.ts
+++ b/examples/next-typescript-starter/middleware.ts
@@ -58,7 +58,7 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     '/',
-    '/((?!_next|favicon.ico|__/auth|__/firebase|api|.*\\.).*)',
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/api/login',
     '/api/logout',
     '/api/refresh-token'


### PR DESCRIPTION
I have a use case in which I have a dynamic route like this `/test/example.json` and the middleware is'n t redirecting the user if the user is not logged in because the request url contains dot and If i'm removing the dot it's working properly. Then after searching a little bit I use the clerk's matcher you can see here [clerk docs](https://clerk.com/docs/references/nextjs/custom-sign-in-or-up-page#make-the-sign-in-or-up-route-public)
and it's working properly