### PR TITLE
Exposing token-verifier for public use

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "./lib/auth": "./lib/auth/index.js",
     "./lib/auth/error": "./lib/auth/error.js",
     "./lib/auth/claims": "./lib/auth/claims.js",
+    "./lib/auth/token-verifier": "./lib/auth/token-verifier.js",
     "./lib/next/utils": "./lib/next/utils.js",
     "./lib/next/cookies": "./lib/next/cookies/index.js",
     "./lib/next/tokens": "./lib/next/tokens.js",


### PR DESCRIPTION
Useful in special cases such as authorize the request websockets requests. 

E.g use case, 
Next app app authorizes using a firbease custom token, this custom token is sent to websoket server, with in the web socket server easy and lightweight way to authorize the user by validating the token `createIdTokenVerifier` wihout all the next js dependencies. 

```
    const idTokenVerifier = createIdTokenVerifier("project-name");
    const decodedToken = await idTokenVerifier.verifyJWT(token, {});

    const { uid, name, exp, picture, email } = decodedToken;
```