### PR TITLE
URL encode redirect param

### DIFF
--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -115,7 +115,10 @@ export function redirectToLogin(
 
   const url = request.nextUrl.clone();
   url.pathname = options.path;
-  url.search = `${redirectKey}=${request.nextUrl.pathname}${url.search}`;
+  const encodedRedirect = encodeURIComponent(
+    `${request.nextUrl.pathname}${url.search}`
+  );
+  url.search = `${redirectKey}=${encodedRedirect}`;
   return NextResponse.redirect(url);
 }
 


### PR DESCRIPTION
Currently, query params that are part of the original request (ex: `https://mysite.com/resources?id=123`) are not URL encoded and will result in a redirect like `https://mysite.com/login?redirect=resources?id=123`.

This change will ensure that the original query params are url-encoded and can be properly read after login.