### PR TITLE
fix(auth): honor GOOGLE_CLOUD_PROJECT before the metadata server in getProjectId

### DIFF
--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -205,6 +205,18 @@ export class ComputeEngineCredential implements Credential {
       return Promise.resolve(this.projectId);
     }
 
+    // Honor an explicitly configured project id (GOOGLE_CLOUD_PROJECT /
+    // GCLOUD_PROJECT) before reaching for the metadata server, matching how
+    // firebase-admin and google-auth-library resolve the project. This lets
+    // the credential work on hosts without the GCP metadata server (behind a
+    // non-GCP load balancer, other clouds, some local/edge setups), where the
+    // metadata lookup otherwise throws "Failed to determine project ID".
+    const explicit = getExplicitProjectId();
+    if (explicit) {
+      this.projectId = explicit;
+      return this.projectId;
+    }
+
     const url = `http://${GOOGLE_METADATA_SERVICE_HOST}${GOOGLE_METADATA_SERVICE_PROJECT_ID_PATH}`;
     const request = this.buildRequest();
 


### PR DESCRIPTION
## Problem

`ComputeEngineCredential.getProjectId()` discovers the project id solely from the GCP metadata server (`metadata.google.internal`). On any host without it — behind a non-GCP load balancer, other clouds (AWS, etc.), some local or edge setups — it throws `Failed to determine project ID: fetch failed`, which surfaces as a 500 on the login route (the middleware needs the project id to verify the id token's `aud`/`iss`).

The library already exports `getExplicitProjectId()` — it reads `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT`, matching how `firebase-admin` and `google-auth-library` resolve the project — but `getProjectId()` never calls it.

## Change

Honor `getExplicitProjectId()` before the metadata lookup. No behavior change on GCP: those env vars are typically present there, and the metadata fallback is untouched when they aren't.
