### PR TITLE
fix(auth): url-encode the refresh token in refreshExpiredIdToken

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -187,7 +187,7 @@ const refreshExpiredIdToken = async (
       'Content-Type': 'application/x-www-form-urlencoded',
       ...(options.referer ? {Referer: options.referer} : {})
     },
-    body: `grant_type=refresh_token&refresh_token=${refreshToken}`
+    body: `grant_type=refresh_token&refresh_token=${encodeURIComponent(refreshToken)}`
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Problem

`refreshExpiredIdToken` builds the `application/x-www-form-urlencoded` body by interpolating the refresh token raw:

```ts
body: `grant_type=refresh_token&refresh_token=${refreshToken}`
```

A refresh-token value containing `&` or `=` would inject additional form parameters into the request to the secure-token endpoint. Firebase-issued refresh tokens are url-safe today, but the value is opaque and, depending on how callers wire up login, can originate from request input — so encoding it is the correct, defensive behavior for a urlencoded body.

## Change

`encodeURIComponent` the refresh token.
